### PR TITLE
ci: use reusable workflows from .github repo

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,49 +2,6 @@ name: automerge
 on:
   pull_request:
     branches: [main]
-
-permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-
 jobs:
-  dependabot:
-    permissions:
-      contents: write
-      pull-requests: write
-
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
-    steps:
-      - id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
-
-      - name: log metadata
-        run: echo "${DEPENDABOT_METADATA}"
-        env:
-          DEPENDABOT_METADATA: ${{ toJson(steps.metadata.outputs) }}
-
-      - name: automerge
-        if: ${{ !contains(steps.metadata.outputs.update-type, 'major' ) }}
-        run: gh pr merge "${PR_NUMBER}" --auto --squash
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-  pre-commit-ci:
-    permissions:
-      contents: write
-      pull-requests: write
-
-    if: ${{ github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: automerge
-        run: gh pr merge "${PR_NUMBER}" --auto --squash
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+  automerge:
+    uses: yxtay/.github/.github/workflows/automerge.yml@main

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,9 +2,10 @@ name: automerge
 on:
   pull_request:
     branches: [main]
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 jobs:
   automerge:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: yxtay/.github/.github/workflows/automerge.yml@main

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,6 +2,9 @@ name: automerge
 on:
   pull_request:
     branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   automerge:
     uses: yxtay/.github/.github/workflows/automerge.yml@main

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -6,10 +6,11 @@ on:
     branches: [main]
   merge_group:
     branches: [main]
-permissions:
-  contents: read
-  id-token: write
-  security-events: write
+permissions: {}
 jobs:
   ossf:
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     uses: yxtay/.github/.github/workflows/ossf.yml@main

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   merge_group:
     branches: [main]
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
 jobs:
   ossf:
     uses: yxtay/.github/.github/workflows/ossf.yml@main

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -6,43 +6,6 @@ on:
     branches: [main]
   merge_group:
     branches: [main]
-  workflow_call:
-  workflow_dispatch:
-
-permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-
 jobs:
   ossf:
-    permissions:
-      contents: read
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
-      # Needed for Code scanning upload
-      security-events: write
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # Scorecard team runs a weekly scan of public GitHub repos,
-          # see https://github.com/ossf/scorecard#public-data.
-          # Setting `publish_results: true` helps us scale by leveraging your workflow to
-          # extract the results instead of relying on our own infrastructure to run scans.
-          # And it's free for you!
-          publish_results: true
-
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: results.sarif
+    uses: yxtay/.github/.github/workflows/ossf.yml@main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
     branches: [main]
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 jobs:
   pr:
     uses: yxtay/.github/.github/workflows/pr.yml@main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
     branches: [main]
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 jobs:
   pr:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: yxtay/.github/.github/workflows/pr.yml@main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,46 +3,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
     branches: [main]
-
-permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-
 jobs:
-  lint-title:
-    permissions:
-      pull-requests: read
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-  label:
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
-
-  label-size:
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff # v0.5.7
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          IGNORED: |
-            package-lock.json
-            *.lock
-            docs/**
+  pr:
+    uses: yxtay/.github/.github/workflows/pr.yml@main

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -6,55 +6,45 @@ on:
     branches: [main]
   merge_group:
     branches: [main]
-  workflow_call:
-  workflow_dispatch:
-
 permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-
 jobs:
+  reusable:
+    uses: yxtay/.github/.github/workflows/scans.yml@main
   megalinter:
     permissions:
       contents: write
       pull-requests: write
       security-events: write
       statuses: write
-
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: ${{ github.event_name == 'pull_request' }} # zizmor: ignore[artipacked]
           fetch-depth: (${{ github.event.pull_request.commits || 2 }} + 1)
-
       - id: megalinter
-        # You can override MegaLinter flavor used to have faster performances
-        # More info at https://megalinter.io/latest/flavors/
         uses: oxsecurity/megalinter/flavors/documentation@0e3ce9b9c8c10effb9b269509cc47ca17cae31c7 # v9
         env:
-          VALIDATE_ALL_CODEBASE: ${{ github.ref_name != github.event.repository.default_branch }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
+          VALIDATE_ALL_CODEBASE: ${{ github.ref_name != github.event.repository.default_branch }}
           DISABLE_ERRORS: ${{ github.ref_name != github.event.repository.default_branch }}
           GITHUB_TOKEN: ${{ github.token }}
-
       - if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: megalinter-reports
           path: megalinter-reports
-
       - if: ${{ success() || failure() }}
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
         with:
           sarif_file: megalinter-reports/megalinter-report.sarif
           ref: ${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.ref }}
           sha: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - if: ${{ steps.megalinter.outputs.has_updated_sources == 1 && github.event_name == 'pull_request' }}
+      - if: ${{ steps.megalinter.outputs.has_updated_sources == 1 && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
         name: commit changes
         run: |
           git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
@@ -63,6 +53,5 @@ jobs:
           git push origin "HEAD:refs/heads/${GITHUB_HEAD_REF}"
         env:
           COMMIT_MESSAGE: "fix: apply megalinter fixes"
-          # https://api.github.com/users/megalinter-bot
           GITHUB_ACTOR: megalinter-bot
           GITHUB_ACTOR_ID: 129584137

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -12,6 +12,11 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 jobs:
   reusable:
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
+      statuses: write
     uses: yxtay/.github/.github/workflows/scans.yml@main
   megalinter:
     permissions:


### PR DESCRIPTION
## Summary

- Replace `automerge.yml`, `pr.yml`, `ossf.yml` with thin callers to `yxtay/.github` reusable workflows
- Reduces maintenance burden — workflow logic centralized in `.github` repo

## Test plan

- [ ] Verify reusable workflows trigger correctly on PR events
- [ ] Confirm automerge still works for dependabot/pre-commit-ci PRs
- [ ] Check OSSF scorecard runs on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored CI workflows to delegate to shared reusable workflows for automerge, OSSF scorecard, and PR validation, reducing duplication and centralizing behavior.
  * Updated scans workflow triggers and lint/report upload conditions to streamline scanning and reporting on main and PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->